### PR TITLE
Only try to decrypt the deploy key when deploying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ language: r
 cache:
   packages: true
 
-# Decrypt the deployment key, used to push the result to the repo
-before_install:
- - openssl aes-256-cbc -K $encrypted_516b420c1ae6_key -iv $encrypted_516b420c1ae6_iv -in deploy_key.enc -out deploy_key -d
-
 # Make bash scripts executable, so they can be run later. 
 before_script:
 - chmod +x ./_build.sh

--- a/_deploy.sh
+++ b/_deploy.sh
@@ -8,6 +8,9 @@ ssh-add deploy_key
 
 if [[ $TRAVIS_BRANCH == 'master' ]]
 then
+  # Decrypt the deploy key
+  openssl aes-256-cbc -K $encrypted_516b420c1ae6_key -iv $encrypted_516b420c1ae6_iv -in deploy_key.enc -out deploy_key -d
+
   # configure your name and email if you have not done so
   git config --global user.email "will@bowdit.ch"
   git config --global user.name "willbowditch"


### PR DESCRIPTION
Just noticed that: 

> Pull requests sent from forked repositories do not have access to encrypted variables or data even if these are defined in the fork source project.

So PR builds will fail, even if everything is fine, when coming from a forked repo. Moving the decryption of the ssh key into the `_deploy.sh` script, that only runs on the master branch, should fix this. 