### PR TITLE
DfE resources

### DIFF
--- a/site/resource-coffee-and-coding.Rmd
+++ b/site/resource-coffee-and-coding.Rmd
@@ -29,7 +29,7 @@ Table: Coffee and coding groups
 | Organisation | Resources | Contact | Notes |
 |--------------|-----------|---------|-------|
 | Department for Business, Energy and Industrial Strategy | `W:/TRAINSHARE` on CBAS (open only to CBAS users in BEIS and partner orgs) | coffeeandcoding@beis.gov.uk | Weekly at 10-11am on Wednesdays, open to all |
-| Department for Education |  | coffee.coding@education.gov.uk |  |
+| Department for Education | https://github.com/dfe-analytical-services/coffee-and-coding | coffee.coding@education.gov.uk | Sessions are usually held on every other Wednesday morning from 10-11AM. Rooms are booked for the London, Sheffield, and Darlington offices. |
 | Department of Health and Social Care | | https://www.eventbrite.co.uk/e/health-r-coding-club-tickets-52481515626 | All events are arranged via the eventbrite link. |
 | Department for Transport | https://github.com/departmentfortransport/coffee-and-coding |  |  |
 | Ministry of Defence | Internal GitLab | Charlie Willis charles.wills106@mod.uk | Usually once a month on Friday mornings |


### PR DESCRIPTION
Added url of the DfE C & C repo, and added notes on when and where C & C sessions are held in the department.