### PR TITLE
Link to tabular data standard

### DIFF
--- a/site/resources.Rmd
+++ b/site/resources.Rmd
@@ -16,4 +16,5 @@ GitHub](https://github.com/ukgovdatascience/rap-website/issues).
 * [NHS NSS Transforming Publications Toolkit](resource-nhs-nss-transforming-publications-toolkit.html)
 * [Use RAP to help conform to the Data Ethics Framework](https://www.gov.uk/guidance/5-use-robust-practices-and-work-within-your-skillset#reproducibility)
 * [Style guides and methodologies](resource-style-guides.html)
+* [Tabular data format standard (CSV)](https://www.gov.uk/government/publications/recommended-open-standards-for-government/tabular-data-standard)
 :::


### PR DESCRIPTION
The Open Standards Board now formally recommends a particular CSV standard for
tabular data.  It isn't mandatory because there are too many exceptions (e.g.
geospatial).  But it's better for RAP than spreadsheets!

https://www.gov.uk/government/publications/recommended-open-standards-for-government/tabular-data-standard