### PR TITLE
Add link to edit C&C page on GitHub

### DIFF
--- a/site/resource-coffee-and-coding.Rmd
+++ b/site/resource-coffee-and-coding.Rmd
@@ -37,3 +37,5 @@ Table: Coffee and coding groups
 | Ministry of Housing Communities and Local Government | Internal Microsoft Teams site 'Coffee & Coding Public' | coffeeandcoding@communities.gov.uk | Roughly fortnightly on Monday afternoon's, held in 2 Marsham Street, London |
 | Ministry of Justice (MoJ) | https://github.com/moj-analytical-services/coffee-and-coding-public | Coffee-and-Coding@justice.gov.uk |  |
 | Office for National Statistics Data Science Campus | https://github.com/datasciencecampus/coffee-and-coding | coffee.coding@ons.gov.uk | Monthly |
+
+[Edit this page on GitHub](https://github.com/ukgovdatascience/rap-website/edit/master/site/resource-coffee-and-coding.Rmd)


### PR DESCRIPTION
Add a link to the Coffee & Coding page to edit the page by editing the file on GitHub.

If people use this, perhaps it could be added to Govdown as a feature.